### PR TITLE
on darwin, rely on -lglfw, not -lglfw3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ LIBFLAGS :=
 DOCDIR := docs
 
 ifeq ($(shell uname -s),Darwin)
-	# glfw3, as installed by Homebrew.
+	# glfw, as installed by Homebrew.
 	CFLAGS += -I/usr/local/include
-	LIBFLAGS += -L/usr/local/lib -framework OpenGL -lglfw3
+	LIBFLAGS += -L/usr/local/lib -framework OpenGL -lglfw
 else
 	LIBFLAGS += -lGL -lglfw -lm
 endif


### PR DESCRIPTION
unbreaks the `make` process for me on darwin (high sierra 10.13.3).

homebrew seems to treat 'glfw3' as an alias for 'glfw', so installing either of
those package names from homebrew should be ok for the glfw prerequisite.  but
the shared library ends up being called libglfw.3.dylib, so use -lglfw, not
-lglfw3.