### PR TITLE
Dynamic library flags must come after the object file using it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,21 @@
-TARGET := tinygl
 SOURCE := tinygl.c
 CFLAGS := -g
-LIBFLAGS :=
 DOCDIR := docs
 
 ifeq ($(shell uname -s),Darwin)
 	# glfw, as installed by Homebrew.
 	CFLAGS += -I/usr/local/include
-	LIBFLAGS += -L/usr/local/lib -framework OpenGL -lglfw
+	LDLIBS := -L/usr/local/lib -framework OpenGL -lglfw
 else
-	LIBFLAGS += -lGL -lglfw -lm
+	LDLIBS := -lGL -lglfw -lm
 endif
 
+TARGET := $(basename $(SOURCE))
 $(TARGET): $(SOURCE)
-	$(CC) $(CFLAGS) $(LIBFLAGS) -o $@ $^
 
 .PHONY: clean
 clean:
-	rm -f $(TARGET)
-	rm -rf $(DOCDIR)
+	$(RM) -r $(TARGET) $(DOCDIR)
 
 # The documentation.
 $(DOCDIR): $(SOURCE)


### PR DESCRIPTION
Simplified the Makefile a bit on the way, using standard names and the usual
implicit rules and variables => principle of least surprise. :-)

Without that fix, you get the following error (Ubuntu cosmic, but will probably be the same on other distros):

```
sp@Klappkatze:~/repos/tinygl (master)$ make
cc -g  -lGL -lglfw -lm -o tinygl tinygl.c
/usr/bin/ld: /tmp/cc1xWoEX.o: in function `create_shader':
/home/sp/repos/tinygl.orig/tinygl.c:80: undefined reference to `glCreateShader'
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:109: undefined reference to `glShaderSource'
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:110: undefined reference to `glCompileShader'
...
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:164: undefined reference to `glGetProgramInfoLog'
/usr/bin/ld: /tmp/cc1xWoEX.o: in function `update_vertices':
/home/sp/repos/tinygl.orig/tinygl.c:176: undefined reference to `cos'
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:177: undefined reference to `sin'
/usr/bin/ld: /tmp/cc1xWoEX.o: in function `main':
/home/sp/repos/tinygl.orig/tinygl.c:186: undefined reference to `glfwInit'
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:187: undefined reference to `glfwWindowHint'
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:188: undefined reference to `glfwWindowHint'
...
/usr/bin/ld: /home/sp/repos/tinygl.orig/tinygl.c:324: undefined reference to `glfwTerminate'
collect2: error: ld returned 1 exit status
make: *** [Makefile:16: tinygl] Error 1
sp@Klappkatze:~/repos/tinygl (master)$ 
```

With the fix applied you get what you want:
```
sp@Klappkatze:~/repos/tinygl (fix-linker-flags)$ make
cc -g    tinygl.c  -lGL -lglfw -lm -o tinygl
sp@Klappkatze:~/repos/tinygl (fix-linker-flags)$ 
```
